### PR TITLE
Feat/leave parking

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,20 @@ rspec
 ```json
 { Validation failed: "Paid can't be processed again" }
 ```
+
+* **PUT /v1/parking/:id/out**: Left parking.
+
+200
+```json
+{ message: "ABC-1234 left parking" }
+```
+
+404
+```json
+{ "Couldn't find Parking with 'id'=999" }
+```
+
+422
+```json
+{ Validation failed: Left unauthorized without paying" }
+```

--- a/app/controllers/v1/parking_controller.rb
+++ b/app/controllers/v1/parking_controller.rb
@@ -19,6 +19,16 @@ class V1::ParkingController < ApplicationController
     render json: e.message, status: :conflict
   end
 
+  def leave
+    parking = ParkingService::Leave.new(parking_leave_params).call
+
+    render json: { message: "#{parking.plate} left parking" }, status: :ok
+  rescue ActiveRecord::RecordNotFound => e
+    render json: e.message, status: :not_found
+  rescue ActiveRecord::RecordInvalid => e
+    render json: e.message, status: :conflict
+  end
+
   private
 
   def parking_params
@@ -26,6 +36,10 @@ class V1::ParkingController < ApplicationController
   end
 
   def parking_payment_params
+    params.permit(:id)
+  end
+
+  def parking_leave_params
     params.permit(:id)
   end
 

--- a/app/models/parking.rb
+++ b/app/models/parking.rb
@@ -1,6 +1,14 @@
 class Parking < ApplicationRecord
+  validate :paying_twice, on: :update
+
   validates :plate, presence: true, length: { is: 8 }, format: { with: /\A[A-Z]{3}-\d{4}\z/ }
   validates :paid, inclusion: { in: [ true, false ] }
   # attr_was a rails method to check attribute before update
-  validate { errors.add(:paid, "can't be processed again") if paid_was && paid }
+  validate { errors.add(:exit_time, "can't leave without paying") if !paid && exit_time_changed? }
+
+  def paying_twice
+    if paid_came_from_user? && paid_was
+      errors.add(:paid, "can't be processed again")
+    end
+  end
 end

--- a/app/models/parking.rb
+++ b/app/models/parking.rb
@@ -4,7 +4,7 @@ class Parking < ApplicationRecord
   validates :plate, presence: true, length: { is: 8 }, format: { with: /\A[A-Z]{3}-\d{4}\z/ }
   validates :paid, inclusion: { in: [ true, false ] }
   # attr_was a rails method to check attribute before update
-  validate { errors.add(:exit_time, "can't leave without paying") if !paid && exit_time_changed? }
+  validate { errors.add(:left, "unauthorized without paying") if !paid && left_changed? }
 
   def paying_twice
     if paid_came_from_user? && paid_was

--- a/app/services/parking_service/leave.rb
+++ b/app/services/parking_service/leave.rb
@@ -1,0 +1,11 @@
+class ParkingService::Leave
+  def initialize(parking_payment_params)
+    @id = parking_payment_params[:id]
+  end
+
+  def call
+    parking = Parking.find(@id)
+    parking.update!(exit_time: DateTime.now)
+    parking
+  end
+end

--- a/app/services/parking_service/leave.rb
+++ b/app/services/parking_service/leave.rb
@@ -1,6 +1,6 @@
 class ParkingService::Leave
-  def initialize(parking_payment_params)
-    @id = parking_payment_params[:id]
+  def initialize(parking_leave_params)
+    @id = parking_leave_params[:id]
   end
 
   def call

--- a/app/services/parking_service/leave.rb
+++ b/app/services/parking_service/leave.rb
@@ -5,7 +5,7 @@ class ParkingService::Leave
 
   def call
     parking = Parking.find(@id)
-    parking.update!(exit_time: DateTime.now)
+    parking.update!(left: true, exit_time: DateTime.now)
     parking
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,5 +11,6 @@ Rails.application.routes.draw do
   namespace :v1 do
     post "/parking", to: "parking#create"
     put "/parking/:id/pay", to: "parking#pay"
+    put "/parking/:id/out", to: "parking#leave"
   end
 end

--- a/spec/controllers/parking_controller_spec.rb
+++ b/spec/controllers/parking_controller_spec.rb
@@ -110,7 +110,7 @@ describe V1::ParkingController, type: :request do
         put "/v1/parking/#{parking.id}/out"
 
         expect(response.status).to eq(409)
-        expect(response.body).to eq("Validation failed: Exit time can't leave without paying")
+        expect(response.body).to eq("Validation failed: Left unauthorized without paying")
       end
     end
   end

--- a/spec/controllers/parking_controller_spec.rb
+++ b/spec/controllers/parking_controller_spec.rb
@@ -79,4 +79,39 @@ describe V1::ParkingController, type: :request do
       end
     end
   end
+
+  describe 'PUT /v1/parking/:id/out' do
+    context 'successfully' do
+      let!(:parking) { Parking.create(plate: 'ABC-1234', entry_time: DateTime.now, paid: true) }
+      let(:expected_response) { { message: "ABC-1234 left parking" } }
+
+      it 'update parking exit time' do
+        put "/v1/parking/#{parking.id}/out"
+
+        expect(response.status).to eq(200)
+        expect(response.body).to eq(expected_response.to_json)
+        expect(Parking.last.exit_time).to be_present
+      end
+    end
+
+    context 'parking not found' do
+      it 'show error message' do
+        put '/v1/parking/999/out'
+
+        expect(response.status).to eq(404)
+        expect(response.body).to include("Couldn't find Parking with 'id'=999")
+      end
+    end
+
+    context 'parking not payed' do
+      let!(:parking) { Parking.create(plate: 'ABC-1234', entry_time: DateTime.now) }
+
+      it 'show error message' do
+        put "/v1/parking/#{parking.id}/out"
+
+        expect(response.status).to eq(409)
+        expect(response.body).to eq("Validation failed: Exit time can't leave without paying")
+      end
+    end
+  end
 end

--- a/spec/controllers/parking_controller_spec.rb
+++ b/spec/controllers/parking_controller_spec.rb
@@ -91,6 +91,7 @@ describe V1::ParkingController, type: :request do
         expect(response.status).to eq(200)
         expect(response.body).to eq(expected_response.to_json)
         expect(Parking.last.exit_time).to be_present
+        expect(Parking.last.left).to eq(true)
       end
     end
 

--- a/spec/services/parking_service/leave_spec.rb
+++ b/spec/services/parking_service/leave_spec.rb
@@ -10,6 +10,7 @@ describe ParkingService::Leave do
 
       it 'update parking exit time' do
         expect { subject }.to change { Parking.last.exit_time }.from(nil).to(within(1.minute).of(DateTime.now))
+        expect(Parking.last.left).to eq(true)
       end
     end
 
@@ -28,6 +29,8 @@ describe ParkingService::Leave do
 
       it 'raise error' do
         expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+        expect(Parking.last.left).to eq(false)
+        expect(Parking.last.exit_time).to be_nil
       end
     end
   end

--- a/spec/services/parking_service/leave_spec.rb
+++ b/spec/services/parking_service/leave_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe ParkingService::Leave do
+  describe '.call' do
+    subject { ParkingService::Leave.new(parking_payment_params).call }
+
+    context 'successfully' do
+      let!(:parking) { Parking.create(plate: 'ABC-1234', entry_time: DateTime.now, paid: true) }
+      let(:parking_payment_params) { { id: parking.id } }
+
+      it 'update parking exit time' do
+        expect { subject }.to change { Parking.last.exit_time }.from(nil).to(within(1.minute).of(DateTime.now))
+      end
+    end
+
+    context 'parking not found' do
+      let!(:parking) { Parking.create(plate: 'ABC-1234', entry_time: DateTime.now, paid: true) }
+      let(:parking_payment_params) { { id: 999_999 } }
+
+      it 'raise error' do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context 'parking not payed' do
+      let!(:parking) { Parking.create(plate: 'ABC-1234', entry_time: DateTime.now) }
+      let(:parking_payment_params) { { id: parking.id } }
+
+      it 'raise error' do
+        expect { subject }.to raise_error(ActiveRecord::RecordInvalid)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary:

This PR adds a new feature to allow parking leaving.

## Changes:

- Fixed validation of paying twice.
- Created new tests for new route, service controller.
- Implemented new route, service, controller to handle leave parking update.
- Updated README.md with the new route.

## Reasoning:

This feature will improve the experience by making possible leave the parking.

## Testing:

- Tested the feature with insomnia.
- Verified that the request results are correct.